### PR TITLE
Fixed notice error passed by reference

### DIFF
--- a/websocket.class.php
+++ b/websocket.class.php
@@ -26,9 +26,11 @@ class WebSocket{
       $this->say("Debugging on\n");
     }
 
+    $write = array();
+    $except = array();
     while(true){
       $changed = $this->sockets;
-      socket_select($changed,$write=NULL,$except=NULL,NULL);
+      socket_select($changed,$write,$except,NULL);
       foreach($changed as $socket){
         if($socket==$this->master){
           $client=socket_accept($this->master);


### PR DESCRIPTION
I get this error:
```
Notice: Only variables should be passed by reference in websocket.class.php on line 31
```
It's because of `socket_select` that happens, because some arguments must be array.
I fixed it.
